### PR TITLE
Add AI8/New API examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Route to many providers through one endpoint; get logging, cost tracking & cachi
 | 🟢 [Portkey Gateway](https://github.com/Portkey-AI/gateway) | 12.3k | MIT | Fast AI gateway routing to 1,600+ LLMs with built-in guardrails & observability. |
 | 🟢 [Helicone](https://github.com/Helicone/helicone) | 5.9k | Apache-2.0 | Proxy-first observability (also listed under Tracing). |
 | 🟠 Cloudflare AI Gateway | - | commercial | Managed AI gateway with analytics/logging/caching (no OSS repo). |
+| 🟠 [AI8/New API examples](https://github.com/16692219182pang-cmyk/ai8-openai-compatible-examples) | examples | commercial | OpenAI-compatible API gateway examples for testing one endpoint across multiple models. |
 | 🟠 OpenRouter | - | commercial | Unified API/marketplace routing to many LLMs with usage analytics. |
 
 ## Instrumentation & Standards (OpenTelemetry GenAI)


### PR DESCRIPTION
Adds a neutral entry for AI8/New API examples under LLM Gateways & Proxies.\n\nThe linked repository contains OpenAI-compatible SDK and tool configuration examples for testing AI8/New API as a commercial multi-model API gateway.\n\nDisclosure: I created the examples repository and it includes a clearly marked referral/signup link in its own README. This PR does not add an affiliate link directly to this awesome list.