### PR TITLE
Add ClawBench to evaluation frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Test and score LLM/agent output. One thing to sort out before you pick a tool: a
 | 🟠 [Athina](https://github.com/athina-ai/athina-evals) | 301 | - | Python SDK for running evals on LLM responses. |
 | 🟢 [HELM](https://github.com/stanford-crfm/helm) | 2.9k | Apache-2.0 | Stanford's Holistic Evaluation of Language Models: broad, multi-metric benchmarking. |
 | 🟢 [RAGChecker](https://github.com/amazon-science/RAGChecker) | 1.1k | Apache-2.0 | Fine-grained framework for diagnosing RAG failures (retriever vs generator). |
+| 🟢 [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) | 525 | Apache-2.0 | End-to-end benchmark framework for browser agents on live websites, with isolated runs, request interception and replayable traces. |
 | 🟢 [continuous-eval](https://github.com/relari-ai/continuous-eval) | 516 | Apache-2.0 | Data-driven, modular evaluation for LLM/RAG pipelines. |
 | 🟠 [Galileo](https://github.com/rungalileo/galileo-python) | SDK | Apache-2.0 | Eval + observability platform; SDK OSS, platform commercial. |
 | 🟠 [Openlayer](https://github.com/openlayer-ai/openlayer-python) | SDK | Apache-2.0 | Testing, eval & monitoring platform; SDK OSS, platform commercial. |


### PR DESCRIPTION
## Summary

- Add ClawBench to the Evaluation Frameworks table.
- Use the current GitHub star count and the repository's Apache-2.0 license.

## Why it fits

ClawBench is an open-source framework for end-to-end browser-agent evaluation on live websites. Its isolated runs, request interception, and replayable execution traces make it relevant to agent testing and evaluation workflows.

Disclosure: I am a maintainer of ClawBench and am proposing this entry in that capacity.
