### PR TITLE
Add ClawBench evaluation benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Test and score LLM/agent output. One thing to sort out before you pick a tool: a
 | 🟠 [Athina](https://github.com/athina-ai/athina-evals) | 301 | - | Python SDK for running evals on LLM responses. |
 | 🟢 [HELM](https://github.com/stanford-crfm/helm) | 2.9k | Apache-2.0 | Stanford's Holistic Evaluation of Language Models: broad, multi-metric benchmarking. |
 | 🟢 [RAGChecker](https://github.com/amazon-science/RAGChecker) | 1.1k | Apache-2.0 | Fine-grained framework for diagnosing RAG failures (retriever vs generator). |
+| 🟢 [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) | 531 | Apache-2.0 | Live-web benchmark for browser and computer-use agents with 283 tasks across 163 websites, request interception, execution traces, and judge-assisted evaluation. |
 | 🟢 [continuous-eval](https://github.com/relari-ai/continuous-eval) | 515 | Apache-2.0 | Data-driven, modular evaluation for LLM/RAG pipelines. |
 | 🟠 [Galileo](https://github.com/rungalileo/galileo-python) | SDK | Apache-2.0 | Eval + observability platform; SDK OSS, platform commercial. |
 | 🟠 [Openlayer](https://github.com/openlayer-ai/openlayer-python) | SDK | Apache-2.0 | Testing, eval & monitoring platform; SDK OSS, platform commercial. |


### PR DESCRIPTION
ClawBench is a live-web benchmark for browser and computer-use agent evaluation, so it fits the Evaluation Frameworks section.

The entry follows the repository table format, uses a neutral one-line description, and is placed by the current project star count relative to neighboring entries.

Disclosure: I help maintain ClawBench.