### PR TITLE
Add telemetry.dev (Tracing & Observability Platforms)

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ End-to-end tracing + dashboards for LLM/RAG/agent apps.
 | 🟠 [Lunary](https://github.com/lunary-ai/lunary-py) | SDK | Apache-2.0 | Analytics, monitoring & evals for GenAI apps (open-core). |
 | 🟠 [Parea AI](https://github.com/parea-ai/parea-sdk-py) | SDK | Apache-2.0 | Experiment, test, evaluate & monitor LLM apps (YC S23). |
 | 🟠 [HoneyHive](https://honeyhive.ai) | - | commercial | Evaluation & observability platform (no primary OSS repo). |
+| 🟠 [telemetry.dev](https://telemetry.dev) | - | commercial | OpenTelemetry-native tracing for LLM/agent apps with per-span tokens, cost, latency & errors; TypeScript SDKs + any OTLP exporter (no OSS repo). |
 | 🟢 [AgentOps](https://github.com/AgentOps-AI/agentops) | 5.7k | MIT | Agent monitoring with session replays, cost + latency tracking, across agent frameworks. |
 | 🟢 [Pydantic Logfire](https://github.com/pydantic/logfire) | 4.4k | MIT | OpenTelemetry-based observability for LLM and agent apps, from the Pydantic team. |
 


### PR DESCRIPTION
Adds one entry to **Tracing & Observability Platforms**, marked 🟠 commercial (no primary OSS repo, same pattern as HoneyHive).

**Disclosure:** I'm the author of telemetry.dev.

Why it fits the list:
- OpenTelemetry-native: any OTLP/HTTP exporter works against the ingest endpoint; also emits/consumes OTel GenAI conventions.
- Per-span tokens, cost (computed server-side from real token usage against per-model pricing), latency, and errors.
- First-party TypeScript SDKs are public on npm: `@telemetry-dev/sdk`, `@telemetry-dev/ai-sdk` (Vercel AI SDK drop-in), `@telemetry-dev/otel`.
- Free tier (10k spans/mo) so anyone can verify the product is real without a card.

Link verified, description kept factual per CONTRIBUTING. One tool, one PR.