### PR TITLE
Add Traceplain to tracing and observability platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ End-to-end tracing + dashboards for LLM/RAG/agent apps.
 | 🟠 [Lunary](https://github.com/lunary-ai/lunary-py) | SDK | Apache-2.0 | Analytics, monitoring & evals for GenAI apps (open-core). |
 | 🟠 [Parea AI](https://github.com/parea-ai/parea-sdk-py) | SDK | Apache-2.0 | Experiment, test, evaluate & monitor LLM apps (YC S23). |
 | 🟠 [HoneyHive](https://honeyhive.ai) | - | commercial | Evaluation & observability platform (no primary OSS repo). |
+| 🟠 [Traceplain](https://traceplain.zakgov.com/?utm_source=github&utm_medium=directory&utm_campaign=contextjet) | - | commercial | Browser-local reviewer that turns Codex, Claude Code, and OTLP JSON agent records into evidence-labelled human handbacks. |
 | 🟢 [AgentOps](https://github.com/AgentOps-AI/agentops) | 5.8k | MIT | Agent monitoring with session replays, cost + latency tracking, across agent frameworks. |
 | 🟢 [Pydantic Logfire](https://github.com/pydantic/logfire) | 4.4k | MIT | OpenTelemetry-based observability for LLM and agent apps, from the Pydantic team. |
 


### PR DESCRIPTION
## What changed

Adds Traceplain to the Tracing & Observability Platforms table as one commercial tool with a factual, single-sentence description.

## Why

Traceplain accepts existing Codex, Claude Code, and OTLP JSON agent records and projects them into a browser-local, evidence-labelled human handback. That makes it relevant to readers comparing ways to inspect agent activity without positioning it as a telemetry collector or full observability backend.

Disclosure: this is a self-submission for a commercial tool.

## Checks

- Added one tool in one best-fit category.
- Used the commercial marker and neutral wording.
- Confirmed the linked page returns HTTP 200.
- Confirmed `git diff --check` passes.