### PR TITLE
Add ClawMetry to Tracing & Observability Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ End-to-end tracing + dashboards for LLM/RAG/agent apps.
 | 🟢 [OpenLIT](https://github.com/openlit/openlit) | 2.7k | Apache-2.0 | OTel-native LLM observability with GPU monitoring, guardrails & evals. |
 | 🟢 [Langtrace](https://github.com/Scale3-Labs/langtrace) | 1.2k | AGPL-3.0 | OpenTelemetry-based end-to-end LLM app observability. |
 | 🟢 [W&B Weave](https://github.com/wandb/weave) | 1.1k | Apache-2.0 | Weights & Biases toolkit for tracing/eval of LLM apps (SaaS backend). |
+| 🟢 [ClawMetry](https://github.com/vivekchand/clawmetry) | 393 | MIT (open-core) | Reads coding-agent session logs from disk instead of proxying calls; sessions, tool calls, tokens and cost for Claude Code, Codex, Cursor, Aider, OpenClaw and others. Two runtimes free, the rest need a license. |
 | 🟠 [LangSmith](https://github.com/langchain-ai/langsmith-sdk) | 1.0k (SDK) | MIT (SDK) | Tracing/eval platform from LangChain; SDK is OSS, backend commercial. |
 | 🟠 [Datadog LLM Observability](https://github.com/DataDog/dd-trace-py) | 648 (tracer) | BSD-3 | LLM Observability product on top of Datadog APM. |
 | 🟠 [New Relic AI Monitoring](https://github.com/newrelic/newrelic-python-agent) | 209 (agent) | Apache-2.0 | AI monitoring integrated into New Relic's agent. |


### PR DESCRIPTION
Adding [ClawMetry](https://github.com/vivekchand/clawmetry) to the tracing table, placed by star count.

It differs from most of the table in where it gets its data: rather than a proxy or an SDK, it reads the session logs coding agent runtimes already write locally, then renders sessions, tool calls, tokens and cache-aware cost. That makes it usable for tools you cannot easily instrument, such as Claude Code, Codex and Cursor. It also accepts OTLP on `/v1/traces`, `/v1/metrics` and `/v1/logs` if you want to send spans in.

I marked it `MIT (open-core)` and noted the split in the description, since only two runtimes are free in the OSS package and the rest need a license. Happy to reword if you would rather phrase that differently.