### PR TITLE
Add XiuRouter to LLM gateways

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Route to many providers through one endpoint; get logging, cost tracking & cachi
 | 🟠 Cloudflare AI Gateway | - | commercial | Managed AI gateway with analytics/logging/caching (no OSS repo). |
 | 🟠 OpenRouter | - | commercial | Unified API/marketplace routing to many LLMs with usage analytics. |
 | 🟢 [Bifrost](https://github.com/maximhq/bifrost) | 7.5k | Apache-2.0 | Fast AI gateway routing to 1,000+ models with logging, cost tracking & governance. |
+| 🟠 [XiuRouter](https://router.xiu.ai/) | - | commercial | Hosted multi-model API gateway with OpenAI, Anthropic Messages and Gemini routes, public usage pricing, and per-request token and cost records. |
 
 ## Instrumentation & Standards (OpenTelemetry GenAI)
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Route to many providers through one endpoint; get logging, cost tracking & cachi
 | 🟠 Cloudflare AI Gateway | - | commercial | Managed AI gateway with analytics/logging/caching (no OSS repo). |
 | 🟠 OpenRouter | - | commercial | Unified API/marketplace routing to many LLMs with usage analytics. |
 | 🟢 [Bifrost](https://github.com/maximhq/bifrost) | 7.5k | Apache-2.0 | Fast AI gateway routing to 1,000+ models with logging, cost tracking & governance. |
-| 🟠 [XiuRouter](https://router.xiu.ai/) | - | commercial | Hosted multi-model API gateway with OpenAI, Anthropic Messages and Gemini routes, public usage pricing, and per-request token and cost records. |
+| 🟠 [XiuRouter](https://router.xiu.ai/) | - | commercial | Hosted, usage-based gateway for OpenAI Chat Completions and Responses, Anthropic Messages, and Gemini GenerateContent, with scoped API keys and per-request token and cost records. |
 
 ## Instrumentation & Standards (OpenTelemetry GenAI)
 


### PR DESCRIPTION
## Summary

Add one XiuRouter row to the existing LLM Gateways & Proxies section. It describes the hosted, usage-based service, documented API protocols, scoped API keys, and per-request token and cost records. The link opens the English documentation directly.

XiuRouter has public documentation, pricing, and self-serve registration. This contribution is made on behalf of its operator, XiuLab Inc; AI assistance was used to prepare and check the change.

## Validation

- Reconciled the original branch with the current upstream table on September 19, 2026, preserving the updated Bifrost row and all other upstream content.
- The final upstream diff is exactly one added table row. No existing row is removed or rewritten.
- `python3 -m pytest skills/ tools/ -q`: 27 passed.
- `git diff --check`: passed.
- English Router docs and protocol compatibility pages return HTTP 200 at their original URLs.
- No automatic failover, fixed savings percentage, free service, or model-family availability is inferred from the supported protocol names.
