### PR TITLE
Add piighost to Guardrails & Safety Monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ The observability layer is standardizing on **OpenTelemetry** - emit these and y
 | 🟢 [LLM Guard](https://github.com/protectai/llm-guard) | 3.2k | MIT | Security toolkit: PII redaction, prompt-injection & toxicity detection. |
 | 🟢 [Presidio](https://github.com/data-privacy-stack/presidio) | 10.6k | MIT | PII detection, redaction & anonymization; the standard for scrubbing prompts and traces. |
 | 🟢 [garak](https://github.com/NVIDIA/garak) | 9.0k | Apache-2.0 | LLM vulnerability scanner: probes for prompt injection, jailbreaks & data leakage (NVIDIA). |
+| 🟢 [piighost](https://github.com/Athroniaeth/piighost) | 11 | MIT | PII de-identification for LLMs. Hides personal data from the model, then restores it for tools and the user. |
 
 ## Self-Hosted / Open-Source First
 


### PR DESCRIPTION
Adds [piighost](https://github.com/Athroniaeth/piighost) to Guardrails & Safety Monitoring. It de-identifies PII for LLMs: it hides personal data from the model with regex/NER/LLM detectors, then restores the real values for tools and the user. Unlike detect-and-block PII tools, it is reversible, so the agent keeps working on real data downstream. Open source (MIT), on PyPI as `piighost`.