### PR TITLE
Add AgentMeasure — conformance checks for agent-telemetry semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ The observability layer is standardizing on **OpenTelemetry** - emit these and y
 | 🟢 [Noveum Trace](https://github.com/Noveum/noveum-trace) | 14 | Apache-2.0 | OpenTelemetry-compliant tracing SDK built specifically for LLM/agent apps. |
 | 🟢 [OTel Semantic Conventions](https://github.com/open-telemetry/semantic-conventions) | 641 | Apache-2.0 | Home of the **GenAI semantic conventions** spec (`gen_ai.*`). |
 | 🟢 [WhyLabs LangKit](https://github.com/whylabs/langkit) | 995 | Apache-2.0 | Extract telemetry/metrics (quality, sentiment, injection signals) from prompts & responses. |
+| 🟢 [AgentMeasure](https://github.com/roy-tong/AgentMeasure) | 34 | MIT | Conformance checks for agent-telemetry semantics: retry grain, token subsets, cache accounting, evidence boundaries — PASS/FAIL/UNPROVABLE via fixtures or a CI Action. |
 
 ## Guardrails & Safety Monitoring
 


### PR DESCRIPTION
Fits the Instrumentation & Standards section: rather than another tracing SDK, AgentMeasure checks whether the metrics your telemetry produces mean what their labels claim (a retry is one operation, not two requests; a reasoning-token subset must not be added into totals; a cache hit is not a new measurement). Ships as reproducible fixtures plus a one-step GitHub Action reporting PASS / FAIL / UNPROVABLE per invariant.

Happy to adjust the description or star count formatting — the count is yours to live-refresh, I just matched the current column.